### PR TITLE
Update course to not show as "public" within name

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-title: Public Reviewing Pull Requests
+title: Reviewing Pull Requests
 tagline: Improve your collaboration on GitHub with pull request reviews.
 description: Learn how to use pull request reviews to communicate and collaborate during the development process.
 template:


### PR DESCRIPTION
Currently, if I visit this course, the name is literally "Public Reviewing Pull Requests". Then, the repository is named "public-reviewing-pull-requests". 

This pull request changes one piece of it so far, but would aim to rename the course to something more natural. 

@beardofedu @ppremk Do you have any ideas to work-around this so we don't also need to rename the other course, but can keep this course from saying "Public" in it's name? 