### PR TITLE
Make sure branch is deleted after merging pr

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -102,6 +102,11 @@ steps:
       - type: mergeBranch
         head: add-multiple-colors
         base: update-colors
+      - type: octokit
+        method: gitdata.deleteReference
+        owner: '%payload.repository.owner.login%'
+        repo: '%payload.repository.name%'
+        ref: heads/add-multiple-colors
       - type: respond
         with: 05_changes-requested.md
 


### PR DESCRIPTION
This should make sure that the branches are _all_ deleted after the bot merges. 