### PR TITLE
Fix last step response

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -200,4 +200,4 @@ steps:
           - type: respond
             with: 08_accidental-close.md
       - type: respond
-        with: 08_comment-final-pr.md
+        with: 08_final-issue.md


### PR DESCRIPTION
I realized that in #62 the config file changed to use `08_comment-final-pr.md`, but also deleted that file. This PR makes it use `08_final-issue.md` instead. You might prefer to revive `08_comment-final-pr.md` - let me know and I can make that adjustment 👍 