### PR TITLE
Fix URL

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -154,6 +154,11 @@ steps:
           type: respond
           with: fix-body.md
       - type: octokit
+        method: repos.getPages
+        owner: '%payload.repository.owner.login%'
+        repo: '%payload.repository.name%'
+        action_id: pagesUrl
+      - type: octokit
         method: pullRequests.createComment
         owner: '%payload.repository.owner.login%'
         repo: '%payload.repository.name%'
@@ -161,7 +166,7 @@ steps:
         path: README.md
         body: |
           ```suggestion
-          You can play the game [here](https://%user.username%.github.io/github-games/)
+          You can play the game [here]('%actions.pagesUrl.data.html_url%')
           ```
 
           Thanks for opening this pull request, @%user.username%.
@@ -170,7 +175,7 @@ steps:
           It looks like this:
 
               ```suggestion
-              You can play the game [here](https://%user.username%.github.io/github-games/)
+              You can play the game [here]('%actions.pagesUrl.data.html_url%')
               ```
 
           ### :keyboard: Activity: Apply the suggestion

--- a/responses/08-suggest-pr.md
+++ b/responses/08-suggest-pr.md
@@ -4,11 +4,9 @@ I've made a suggested change to this pull request because I think you should lin
 
 It looks like this:
 
-#TODO FIX LINK
-
 ```
 ```suggestion
-You can play the game at: https://{{ user.username }}.github.io/github-games/
+You can play the game at: {{ pagesUrl }}
 ```
 ```
 


### PR DESCRIPTION
This pull request aims to fix the URL to the pages site, but I'm not quite sure how to do that. For the time being I've pointed it out, and we can fix it once we know how to do so on GHES. 

cc @githubtraining/learning-engineering @githubtraining/trainers 